### PR TITLE
Copy Servant.Links toLink implementations

### DIFF
--- a/servant-queryparam-core/src/Servant/QueryParam/Record.hs
+++ b/servant-queryparam-core/src/Servant/QueryParam/Record.hs
@@ -11,11 +11,13 @@
 -- | This module provides functions and instances for working with query parameter records.
 module Servant.QueryParam.Record (RecordParam, UnRecordParam) where
 
+import qualified Data.List as List
 import Data.Kind
 import Data.Proxy
 import GHC.Generics
 import GHC.TypeLits
 import Servant.API
+import Servant.Links
 import Servant.QueryParam.TypeLevel
 
 -- | 'RecordParam' uses fields in a record to represent query parameters.
@@ -149,13 +151,15 @@ instance
   ( KnownSymbol sym
   , KnownSymbol (Eval (mod sym))
   , ToHttpApiData a
-  , HasLink (a :> sub)
   , HasLink sub
   ) =>
   GHasLink mod (S1 ('MetaSel ('Just sym) d1 d2 d3) (Rec0 [a])) sub
   where
   gToLink _ toA _ l (M1 (K1 x)) =
-    toLink toA (Proxy :: Proxy (QueryParams (Eval (mod sym)) a :> sub)) l x
+    toLink toA (Proxy :: Proxy sub) $
+    List.foldl' (\l' v -> addQueryParam (ArrayElemParam k (toQueryParam v)) l') l x
+    where
+      k = symbolVal (Proxy :: Proxy sym)
   {-# INLINE gToLink #-}
 
 instance
@@ -163,13 +167,16 @@ instance
   ( KnownSymbol sym
   , KnownSymbol (Eval (mod sym))
   , ToHttpApiData a
-  , HasLink (a :> sub)
   , HasLink sub
   ) =>
   GHasLink mod (S1 ('MetaSel ('Just sym) d1 d2 d3) (Rec0 (Maybe a))) sub
   where
   gToLink _ toA _ l (M1 (K1 x)) =
-    toLink toA (Proxy :: Proxy (QueryParam' '[Optional, Strict] (Eval (mod sym)) a :> sub)) l x
+    toLink toA (Proxy :: Proxy sub) $
+    maybe id (addQueryParam . SingleParam k . toQueryParam) x l
+    where
+      k :: String
+      k = symbolVal (Proxy :: Proxy sym)
   {-# INLINE gToLink #-}
 
 instance
@@ -177,11 +184,14 @@ instance
   ( KnownSymbol sym
   , KnownSymbol (Eval (mod sym))
   , ToHttpApiData a
-  , HasLink (a :> sub)
   , HasLink sub
   ) =>
   GHasLink mod (S1 ('MetaSel ('Just sym) d1 d2 d3) (Rec0 a)) sub
   where
   gToLink _ toA _ l (M1 (K1 x)) =
-    toLink toA (Proxy :: Proxy (QueryParam' '[Required, Strict] (Eval (mod sym)) a :> sub)) l x
+    toLink toA (Proxy :: Proxy sub) $
+    (addQueryParam . SingleParam k . toQueryParam) x l
+    where
+      k :: String
+      k = symbolVal (Proxy :: Proxy sym)
   {-# INLINE gToLink #-}

--- a/servant-queryparam-core/src/Servant/QueryParam/Record.hs
+++ b/servant-queryparam-core/src/Servant/QueryParam/Record.hs
@@ -11,8 +11,8 @@
 -- | This module provides functions and instances for working with query parameter records.
 module Servant.QueryParam.Record (RecordParam, UnRecordParam) where
 
-import qualified Data.List as List
 import Data.Kind
+import Data.List qualified as List
 import Data.Proxy
 import GHC.Generics
 import GHC.TypeLits
@@ -157,9 +157,9 @@ instance
   where
   gToLink _ toA _ l (M1 (K1 x)) =
     toLink toA (Proxy :: Proxy sub) $
-    List.foldl' (\l' v -> addQueryParam (ArrayElemParam k (toQueryParam v)) l') l x
-    where
-      k = symbolVal (Proxy :: Proxy sym)
+      List.foldl' (\l' v -> addQueryParam (ArrayElemParam k (toQueryParam v)) l') l x
+   where
+    k = symbolVal (Proxy :: Proxy sym)
   {-# INLINE gToLink #-}
 
 instance
@@ -173,10 +173,10 @@ instance
   where
   gToLink _ toA _ l (M1 (K1 x)) =
     toLink toA (Proxy :: Proxy sub) $
-    maybe id (addQueryParam . SingleParam k . toQueryParam) x l
-    where
-      k :: String
-      k = symbolVal (Proxy :: Proxy sym)
+      maybe id (addQueryParam . SingleParam k . toQueryParam) x l
+   where
+    k :: String
+    k = symbolVal (Proxy :: Proxy sym)
   {-# INLINE gToLink #-}
 
 instance
@@ -190,8 +190,8 @@ instance
   where
   gToLink _ toA _ l (M1 (K1 x)) =
     toLink toA (Proxy :: Proxy sub) $
-    (addQueryParam . SingleParam k . toQueryParam) x l
-    where
-      k :: String
-      k = symbolVal (Proxy :: Proxy sym)
+      (addQueryParam . SingleParam k . toQueryParam) x l
+   where
+    k :: String
+    k = symbolVal (Proxy :: Proxy sym)
   {-# INLINE gToLink #-}


### PR DESCRIPTION
By the looks of it, the `HasLink (a :> sub)` constraint is what causes #1. It tries to turn the plain record value into a `HasLink`, discarding the key value from the field name. I'm not sure what to use instead to make this idea work but copying over the specific implementations for `QueryParam` etc. seems to fix the problem too.

Fixes #1.